### PR TITLE
Issue #18: Admin middleware + layout + login at /admin/login

### DIFF
--- a/src/app/admin/dashboard/page.tsx
+++ b/src/app/admin/dashboard/page.tsx
@@ -1,0 +1,9 @@
+// Dashboard content — implemented in Issue #20
+export default function AdminDashboardPage() {
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-semibold text-gray-900">Boreas Admin</h1>
+      <p className="mt-2 text-gray-500">Dashboard en construcción — Issue #20</p>
+    </div>
+  )
+}

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+
+export const metadata: Metadata = {
+  title: {
+    default: 'Admin — Boreas',
+    template: '%s | Admin Boreas',
+  },
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+    },
+  },
+}
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      {children}
+    </div>
+  )
+}

--- a/src/app/admin/login/page.tsx
+++ b/src/app/admin/login/page.tsx
@@ -1,0 +1,152 @@
+'use client'
+
+import { useState, Suspense } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase/client'
+import { Eye, EyeOff, Loader2 } from 'lucide-react'
+
+function AdminLoginForm() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    setLoading(true)
+
+    try {
+      // Attempt Supabase auth
+      const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
+        email,
+        password,
+      })
+
+      if (authError || !authData.user) {
+        setError('Credenciales incorrectas')
+        setLoading(false)
+        return
+      }
+
+      // Verify admin role
+      const { data: profileData } = await supabase
+        .from('users')
+        .select('role')
+        .eq('id', authData.user.id)
+        .single() as { data: { role: string } | null; error: unknown }
+
+      if (!profileData || profileData.role !== 'admin') {
+        // Sign out immediately — don't reveal the role check failed
+        await supabase.auth.signOut()
+        setError('Credenciales incorrectas')
+        setLoading(false)
+        return
+      }
+
+      // Admin confirmed — navigate to dashboard
+      router.push('/admin/dashboard')
+    } catch {
+      setError('Error al iniciar sesión. Intenta nuevamente.')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100 py-12 px-4">
+      <div className="max-w-sm w-full">
+        {/* Header */}
+        <div className="text-center mb-8">
+          <div className="w-10 h-10 bg-gray-800 rounded-lg flex items-center justify-center mx-auto mb-4">
+            <span className="text-white font-bold text-lg">B</span>
+          </div>
+          <h1 className="text-xl font-semibold text-gray-900">Acceso interno</h1>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm p-6 space-y-4">
+          <div>
+            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500"
+              placeholder="email@boreas.mx"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+              Contraseña
+            </label>
+            <div className="relative">
+              <input
+                id="password"
+                type={showPassword ? 'text' : 'password'}
+                autoComplete="current-password"
+                required
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full px-3 py-2 pr-10 border border-gray-300 rounded-md text-sm text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:border-gray-500"
+                placeholder="Contraseña"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute inset-y-0 right-0 pr-3 flex items-center text-gray-400 hover:text-gray-600"
+                aria-label={showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'}
+              >
+                {showPassword ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+              </button>
+            </div>
+          </div>
+
+          {/* Error message */}
+          {error && (
+            <div
+              data-testid="error-message"
+              className="rounded-md bg-red-50 border border-red-200 p-3"
+            >
+              <p className="text-sm text-red-700">{error}</p>
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full flex justify-center items-center gap-2 py-2 px-4 bg-gray-800 hover:bg-gray-900 text-white text-sm font-medium rounded-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Verificando...
+              </>
+            ) : (
+              'Entrar'
+            )}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminLoginPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-100">
+        <Loader2 className="w-6 h-6 animate-spin text-gray-500" />
+      </div>
+    }>
+      <AdminLoginForm />
+    </Suspense>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation'
+
+export default function AdminRoot() {
+  redirect('/admin/dashboard')
+}

--- a/src/app/admin/unauthorized/page.tsx
+++ b/src/app/admin/unauthorized/page.tsx
@@ -1,0 +1,9 @@
+export default function UnauthorizedPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="text-center">
+        <p className="text-gray-500 text-sm">Acceso no disponible</p>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
- middleware.ts: protect /admin/* routes with Supabase role check
  - No session → redirect to /admin/login
  - Session without role=admin → redirect to /admin/unauthorized
  - Admin on /admin/login → redirect to /admin/dashboard
  - Removed obsolete /dashboard and /auth redirect rules

- src/app/admin/layout.tsx: noindex/nofollow meta, neutral bg
- src/app/admin/page.tsx: redirect to /admin/dashboard
- src/app/admin/login/page.tsx: admin-only login form
  - No register link, no public site links
  - Verifies role=admin after auth; signs out if not admin
  - Generic error message for both bad creds and wrong role
- src/app/admin/unauthorized/page.tsx: minimal access denied page
- src/app/admin/dashboard/page.tsx: placeholder for Issue #20